### PR TITLE
Prepare release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2025-04-22
+
+### Added
+* HaRP support 
+* default number of 1 for generating images
+* allowing different image sizes
+
+### Changed
+* bumped max NC version to 32
+
+### Fixed
+* CPU support
+
 ## [1.0.6] - 2025-04-22
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 APP_ID := text2image_stablediffusion2
 APP_NAME := Local Image Generation: Stable diffusion
-APP_VERSION := 1.0.6
+APP_VERSION := 1.1.0
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":9030}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@ Text2Image provider using Stable Diffusion XL by Stability AI
 The models run completely on your machine. No private data leaves your servers.
 ]]>
 	</description>
-	<version>1.0.6</version>
+	<version>1.1.0</version>
 	<licence>MIT</licence>
 	<author mail="mklehr@gmx.net" homepage="https://marcelklehr.de">Marcel Klehr</author>
 	<namespace>Text2ImageStableDiffusion2</namespace>
@@ -26,7 +26,7 @@ The models run completely on your machine. No private data leaves your servers.
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud/text2image_stablediffusion2</image>
-			<image-tag>1.0.6</image-tag>
+			<image-tag>1.1.0</image-tag>
 		</docker-install>
 	</external-app>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ The models run completely on your machine. No private data leaves your servers.
 	<bugs>https://github.com/nextcloud/text2image_stablediffusion2/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/text2image_stablediffusion2</repository>
 	<dependencies>
-		<nextcloud min-version="30" max-version="31"/>
+		<nextcloud min-version="30" max-version="32"/>
 	</dependencies>
 	<external-app>
 		<docker-install>


### PR DESCRIPTION
### Added
* HaRP support 
* default number of 1 for generating images
* allowing different image sizes

### Changed
* bumped max NC version to 32

### Fixed
* CPU support